### PR TITLE
Add missing RM4 pro codes

### DIFF
--- a/src/remote.rs
+++ b/src/remote.rs
@@ -23,6 +23,9 @@ use crate::{
 
 /// A mapping of remote device codes to their friendly model equivalent.
 pub const REMOTE_CODES: phf::Map<u16, &'static str> = phf_map! {
+    0x520Bu16 => "RM4 Pro",
+    0x5213u16 => "RM4 Pro",
+    0x5218u16 => "RM4C Pro",
     0x6026u16 => "RM4 Pro",
     0x6184u16 => "RMC4 Pro",
     0x61A2u16 => "RM4 Pro",


### PR DESCRIPTION
Using this library in my home automation, saw that the code of my RM4 Pro was missing in the `REMOTE_CODES` constant.
It was included in `python-broadlink`, so copied the missing RM4 Pro codes from there.