### PR TITLE
Remove panics via expect

### DIFF
--- a/src/network/wireless_connection.rs
+++ b/src/network/wireless_connection.rs
@@ -94,15 +94,15 @@ impl WirelessConnection<'_> {
             // Grab info from connection
             ssid: ssid_fixed,
             password: pass_fixed,
-            ssid_length: u8::try_from(ssid.len()).expect("Could not use provided SSID! SSID is too long (max 32 characters)."),
-            password_length: u8::try_from(pass.len()).expect("Could not use provided password! Password is too long (max 32 characters)."),
+            ssid_length: u8::try_from(ssid.len()).map_err(|e| format!("Could not use provided SSID! SSID is too long (max 32 characters). {}", e))?,
+            password_length: u8::try_from(pass.len()).map_err(|e| format!("Could not use provided password! Password is too long (max 32 characters). {}", e))?,
 
             security_mode: security_mode,
         };
 
         // Add the checksum into the msg
         msg.checksum = checksum(
-            &msg.pack().expect("Could not pack WirelessConnectionMessage!")
+            &msg.pack().map_err(|e| format!("Could not pack WirelessConnectionMessage! {}", e))?
         );
 
         // Return the newly created message


### PR DESCRIPTION
My application kept crashing due to panics when the broadlink device was temporary unavailable. I refactored all `.expect` calls to `.map_err` to return string errors for all errors. The original error is appended to still be able to determine the root cause.

Would probably be better to use an Error type instead to be able to reason about the origin of the error programmatically and prevent allocation of strings when the error is not displayed.
Don't really have a use-case for that now though, so strings are fine.