### PR TITLE
network/command: verify payload checksum

### DIFF
--- a/src/network/command.rs
+++ b/src/network/command.rs
@@ -152,6 +152,16 @@ impl CommandMessage {
         let decrypted = cipher.decrypt_vec(&bytes[0x38..])
             .expect("Could not decrypt command payload!");
 
+        // Ensure that the payload checksums match
+        let real_checksum = checksum(&decrypted);
+        if command_header.payload_checksum != real_checksum {
+            return Err(format!(
+                "Payload checksum does not match actual checksum! Expected {} got {}",
+                real_checksum,
+                command_header.payload_checksum,
+            ));
+        }
+
         return Ok(decrypted);
     }
 }


### PR DESCRIPTION
The code was only checking for whole packet checksum. Now it is also checked whether the decrypted payload checksum matches.